### PR TITLE
fixed a bug building docker image

### DIFF
--- a/services/base/Dockerfile
+++ b/services/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:19.10
 
 LABEL maintainer="SWIM EUROCONTROL <http://www.eurocontrol.int>"
 


### PR DESCRIPTION
The bug is caused by python-gevent not being available in ubuntu:20.04. Selecting a version of the base image that contains the dependency fixes the issue.